### PR TITLE
implement async hooks for factory. Closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ var user = build('User');
 var user = build('User', { override: 'attributes' });
 ```
 
+### Use hooks for creating relationships
+
+```js
+define('Account', Account)
+  .hook('pre:save', function(obj, next) {
+    if (!obj.get('owner')) { // if (!obj.owner) {
+      factory('User', function(err, user) {
+        if (err) return next(err);
+        obj.set('owner', user);
+        next();
+      });
+    } else {
+      next();
+    }
+  })
+```
+
 ### Get model attributes from a factory
 
 ```js

--- a/lib/seed-forge/factory.js
+++ b/lib/seed-forge/factory.js
@@ -2,7 +2,9 @@
  * Dependencies.
  */
 
+var Emitter = require('evts');
 var merge = require('super');
+var inherits = merge.inherits;
 var filtr = require('filtr');
 var cyclop = require('cyclop');
 var factories = require('./factories')
@@ -16,12 +18,13 @@ var clone = merge;
  */
 
 function Factory(Model) {
+  Emitter.call(this);
   this.Model = Model;
   this.attributes = {};
-  this._before = [];
-  this._after = [];
   this.i = 0;
 }
+
+inherits(Factory, Emitter);
 
 /**
  * Set a value for an attribute.
@@ -37,30 +40,38 @@ Factory.prototype.set = function(name, value) {
   return this;
 };
 
-/**
- * Set a before filter.
- *
- * @param {Function} fn
- * @returns `this`
- * @api public
- */
-
-Factory.prototype.before = function(fn) {
-  this._before.push(fn);
+Factory.prototype.hook = function(key, fn) {
+  this.on(key, fn);
   return this;
 };
 
 /**
- * Set an after filter.
+ * Set a pre:build hook.
  *
  * @param {Function} fn
  * @returns `this`
  * @api public
+ * @depreciated
+ */
+
+Factory.prototype.before = function(fn) {
+  return this.hook('pre:build', fn);
+};
+
+/**
+ * Set an post:save hook.
+ *
+ * @param {Function} fn
+ * @returns `this`
+ * @api public
+ * @depreciated
  */
 
 Factory.prototype.after = function(fn) {
-  this._after.push(fn);
-  return this;
+  // maintain compat with old versions
+  return this.hook('post:save', function(obj, next) {
+    fn(next);
+  });
 };
 
 /**
@@ -74,33 +85,20 @@ Factory.prototype.after = function(fn) {
 Factory.prototype.create = function(attrs, fn) {
   var self = this;
 
-  this.runFilter(this._before, function() {
+  this.emit('pre:build', function(err) {
+    if (err) return fn(err);
     var obj = self.build(attrs)
-    obj.save(function (err) {
+    self.emit('pre:save', obj, function(err) {
       if (err) return fn(err);
-      self.runFilter(self._after, function() {
-        fn(null, obj);
+      obj.save(function (err) {
+        if (err) return fn(err);
+        self.emit('post:save', obj, function(err) {
+          if (err) return fn(err);
+          fn(null, obj);
+        });
       });
     });
   });
-};
-
-/**
- * Run a group of filters.
- *
- * @param {Array} group
- * @param {Function} fn
- * @api private
- */
-
-Factory.prototype.runFilter = function(group, fn) {
-  var factories = cyclop();
-
-  group.forEach(function(cb) {
-    factories.push(cb.bind(this));
-  }, this);
-
-  factories.run(fn.bind(this));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "super": "0.2.x",
     "filtr": "0.3.x",
-    "cyclop": "~0.1.0"
+    "cyclop": "~0.1.0",
+    "evts": "~0.1.0"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
Replaces factory `.before()` and `.after()` with `.hook(key, fn)`. 
- `.before()` and `.after()` still work the same but are considered depreciated
- hooks are `pre:build`, `pre:save`, `post:save`
- `*:save` hooks receive the object that was built as the first argument

Closes #1
